### PR TITLE
Pass defaults

### DIFF
--- a/modules/processes/grow_annotation_forest.nf
+++ b/modules/processes/grow_annotation_forest.nf
@@ -36,10 +36,9 @@ process growAnnotationForest {
         # -------------------------
         # FAUST Data
         # -------------------------
-        active_channels_rds_object <- readRDS("${active_channels_path_channel}")
 
         metadata_directory <- file.path("${project_path}", "faustData", "metaData")
-
+        active_channels_rds_object <- readRDS(file.path(metadata_directory,"activeChannels.rds"))
         sanitized_cell_pop_file_path <- file.path(metadata_directory, "sanitizedCellPopStr.rds")
         sanitized_cell_pop_rds_object <- readRDS(sanitized_cell_pop_file_path)
         analysis_map_file_path <- file.path(metadata_directory, "analysisMap.rds")

--- a/modules/processes/prepare_faust_data.nf
+++ b/modules/processes/prepare_faust_data.nf
@@ -46,7 +46,19 @@ process prepareFAUSTData {
         active_channels_rds_object <- readRDS("${active_channels_path_channel}")
         channel_bounds_rds_object <- readRDS("${channel_bounds_path_channel}")
         supervised_list_rds_object <- readRDS("${supervised_list_path_channel}")
-
+        if(is.null(active_channels_rds_object)){
+            active_channels_rds_object<-flowWorkspace::markernames(gating_set)
+        }else if(is.na(active_channels_rds_object)){
+            active_channels_rds_object<-flowWorkspace::markernames(gating_set)
+        }
+        if(is.null(channel_bounds_rds_object)){
+            channel_bounds_rds_object<-""
+        }else if(is.na(channel_bounds_rds_object)){
+            channel_bounds_rds_object<-""
+        }
+        if(is.null(supervised_list_rds_object)){
+            supervised_list_rds_object<-NA
+        }
         gating_set_p_data <- flowWorkspace::pData(gating_set)
         sample_names_rds_object <- flowWorkspace::sampleNames(gating_set)
 


### PR DESCRIPTION
- does some checks on the contents of the rds files.
- sets reasonable defaults same as the faust interface, when appropriate
- reads from the faustData active channels (which is stored to disk by step 1) in subsequent steps (rather than the active channels rds being passed around beyond step one.
